### PR TITLE
fixed incorrect image url generation, when Storage disk was disregarded

### DIFF
--- a/src/FieldController.php
+++ b/src/FieldController.php
@@ -27,7 +27,7 @@ class FieldController extends BaseController
 
             $data[] = [
                 'image' => $image->getClientOriginalName(),
-                'url' => Storage::url($savedImage)
+                'url' => Storage::disk($disk)->url($savedImage),
             ];
         }
 


### PR DESCRIPTION
Please apply this commit, because it's impossible to use your nice nova package with Amazon s3 services