### PR TITLE
Fix upstream #14 image deletion

### DIFF
--- a/dist/js/field.js
+++ b/dist/js/field.js
@@ -543,9 +543,16 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             });
         },
         deleteImage: function deleteImage(index) {
-            axios.delete('/nova-vendor/array-images/delete/' + this.images[index].name);
-            this.images.splice(index, 1);
-            this.value = JSON.stringify(this.images);
+            var image = this.images[index]
+            var saved_path = image.saved_path
+            var params = { disk: this.field.disk }
+
+            axios.delete('/nova-vendor/array-images/delete/' + encodeURIComponent(saved_path), { params })
+              .then(() => {
+                this.images.splice(index, 1)
+                this.value = JSON.stringify(this.images)
+              })
+              .catch(console.warn)
         },
 
 
@@ -4471,7 +4478,7 @@ function singularOrPlural(value, suffix) {
 
 /**
  * Javascript inflector
- * 
+ *
  * @author Dida Nurwanda <didanurwanda@gmail.com>
  * @since 1.0
  */
@@ -4570,7 +4577,7 @@ var _Inflector = {
     Inflector.pluralize('person')           -> 'people'
     Inflector.pluralize('octopus')          -> 'octopi'
     Inflector.pluralize('Hat')              -> 'Hats'
-    Inflector.pluralize('person', 'guys')   -> 'guys'    
+    Inflector.pluralize('person', 'guys')   -> 'guys'
     */
     pluralize: function(str, plural) {
         return this.applyRules(
@@ -4591,7 +4598,7 @@ var _Inflector = {
         return this.applyRules(
             str,
             this.singularRules,
-            this.uncountableWords, 
+            this.uncountableWords,
             singular
         );
     },
@@ -4615,7 +4622,7 @@ var _Inflector = {
         }
         str = str_path.join('::');
 
-        // fix 
+        // fix
         if (lowFirstLetter === true) {
           var first = str.charAt(0).toLowerCase();
           var last = str.slice(1);
@@ -4629,7 +4636,7 @@ var _Inflector = {
     Inflector.underscore('MessageProperties')       -> 'message_properties'
     Inflector.underscore('messageProperties')       -> 'message_properties'
     */
-    underscore: function(str) { 
+    underscore: function(str) {
         var str_path = str.split('::');
         for (var i = 0; i < str_path.length; i++)
         {
@@ -4735,7 +4742,7 @@ var _Inflector = {
     /*
     Inflector.foreignKey('MessageBusProperty')       -> 'message_bus_property_id'
     Inflector.foreignKey('MessageBusProperty', true) -> 'message_bus_propertyid'
-    */   
+    */
     foreignKey: function(str, dropIdUbar) {
         str = this.underscore(this.demodulize(str)) + ((dropIdUbar) ? ('') : ('_')) + 'id';
         return str;

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -86,9 +86,14 @@ export default {
         },
 
         deleteImage(index) {
-            axios.delete('/nova-vendor/array-images/delete/'+this.images[index].name);
-            this.images.splice(index, 1);
-            this.value = JSON.stringify(this.images);
+            const { saved_path } = this.images[index]
+            const params = { disk: this.field.disk }
+            axios.delete('/nova-vendor/array-images/delete/' + encodeURIComponent(saved_path), { params })
+              .then(() => {
+                this.images.splice(index, 1);
+                this.value = JSON.stringify(this.images);
+              })
+              .catch(console.warn)
         },
 
         /*

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,4 +4,5 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/', 'Halimtuhu\ArrayImages\FieldController@index');
 Route::post('/upload', 'Halimtuhu\ArrayImages\FieldController@upload');
-Route::delete('/delete/{image}', 'Halimtuhu\ArrayImages\FieldController@delete');
+Route::delete('/delete/{saved_path}', 'Halimtuhu\ArrayImages\FieldController@delete')
+    ->where('saved_path', '(.*)');

--- a/src/FieldController.php
+++ b/src/FieldController.php
@@ -27,6 +27,7 @@ class FieldController extends BaseController
 
             $data[] = [
                 'image' => $savedImage,
+                'saved_path' => $savedImage,
                 'url' => Storage::disk($disk)->url($savedImage),
             ];
         }
@@ -34,10 +35,14 @@ class FieldController extends BaseController
         return $data;
     }
 
-    public function delete($image)
+    public function delete(Request $request, $saved_path)
     {
-        Storage::delete($image);
+        $disk = $request->disk ? $request->disk : 'local';
 
-        return "success";
+        $deleted = Storage::disk($disk)->delete($saved_path);
+
+        return $deleted === true
+            ? 'success'
+            : response('not deleted', 404);
     }
 }


### PR DESCRIPTION
- The disk is taken into account to locate the file onto which was uploaded.
- The saved_path is sent to the `delete` action, and only in success response the image is removed from the client array.